### PR TITLE
Add blocklist support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bncode": "^0.5.2",
     "compact2string": "^1.2.0",
     "random-access-file": "^0.3.1",
-    "magnet-uri": "^1.1.0"
+    "magnet-uri": "^1.1.0",
+    "ip": "^0.3.0"
   }
 }


### PR DESCRIPTION
This PR adds support for blocklists which allows rejecting peers based on a set of predefined IP address ranges. The blocklist format that is expected is an array of objects, each with a `startAddress` and `endAddress` and optionally a `reason`.

This only implements support for IPv4 addresses.
