### PR TITLE
support `destroy` callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -597,11 +597,15 @@ var torrentStream = function(link, opts) {
 		rimraf(engine.path, cb || noop);
 	};
 
-	engine.destroy = function() {
+	engine.destroy = function(cb) {
 		swarm.destroy();
 		if (engine.tracker) engine.tracker.stop();
 		if (engine.dht) engine.dht.close();
-		if (engine.store) engine.store.close();
+		if (engine.store) {
+			engine.store.close(cb);
+		} else if (cb) {
+			process.nextTick(cb);
+		}
 	};
 
 	engine.listen = function(port, cb) {

--- a/storage.js
+++ b/storage.js
@@ -60,7 +60,7 @@ module.exports = function(folder, torrent) {
 			next.close(loop);
 		};
 
-		loop();
+		process.nextTick(loop);
 	};
 
 	return that;

--- a/test/basic.js
+++ b/test/basic.js
@@ -20,25 +20,21 @@ var engine = function() {
 
 test('fixture can connect to the dht', function(t) {
 	t.plan(1);
-	fixture.on('ready', function() {
-		t.ok(true);
-	});
+	fixture.on('ready', t.ok.bind(t, true, 'should be ready'));
 });
 
 test('destroy engine after ready', function(t) {
 	t.plan(1);
 	var e = engine();
 	e.on('ready', function() {
-		e.destroy();
-		t.ok(true);
+		e.destroy(t.ok.bind(t, true, 'should be destroyed'));
 	});
 });
 
 test('destroy engine right away', function(t) {
 	t.plan(1);
 	var e = engine();
-	e.destroy();
-	t.ok(true);
+	e.destroy(t.ok.bind(t, true, 'should be destroyed'));
 });
 
 test('remove fixture and all content', function(t) {


### PR DESCRIPTION
`destroy` should support a callback to allow safe shutdown in case of
SIGTERM or SIGINT
