### PR TITLE
override DHT size

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Create a new engine instance. Options can contain the following
 	path: '/tmp/my-file', // Where to save the buffer data.
 	verify: true,         // Verify previously stored data before starting
 	                      // Defaults to true
-	dht: true             // Whether or not to use the dht to find peers.
-	                      // Defaults to true
+	dht: 10000,           // Use DHT to initialize the swarm.
+	                      // Defaults to 10000 peers, set false to disable
 	tracker: true         // Whether or not to use a tracker
 	                      // Defaults to true
 }

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ var CHOKE_TIMEOUT = 5000;
 var REQUEST_TIMEOUT = 30000;
 var SPEED_THRESHOLD = 3 * piece.BLOCK_SIZE;
 var DEFAULT_PORT = 6881;
+var DHT_SIZE = 10000;
 
 var METADATA_BLOCK_SIZE = 1 << 14;
 var METADATA_MAX_SIZE = 1 << 22;
@@ -116,7 +117,7 @@ var torrentStream = function(link, opts) {
 				engine.connect(addr);
 			}
 		});
-		table.findPeers(10000); // TODO: be smarter about finding peers
+		table.findPeers(opts.dht || DHT_SIZE); // TODO: be smarter about finding peers
 	}
 
 	var ontorrent = function(torrent) {


### PR DESCRIPTION
using DHT to find peers can be a resource-intensive operation - allow users to override the defaults
