### PR TITLE
Only open existing files for reading

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "parse-torrent": "^0.6.0",
     "peer-wire-swarm": "^0.9.0",
     "random-access-file": "^0.3.1",
-    "rimraf": "^2.2.5",
-    "thunky": "^0.1.0"
+    "rimraf": "^2.2.5"
   },
   "devDependencies": {
     "tap": "^0.4.8"

--- a/storage.js
+++ b/storage.js
@@ -3,7 +3,6 @@ var path = require('path');
 var raf = require('random-access-file');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
-var thunky = require('thunky');
 
 var noop = function() {};
 


### PR DESCRIPTION
One detail: to prevent a multiple `fs.exists` calls, the "nonexistence" of a file is cached until this file is open for writing. If another process creates this file in the meantime, `open()` will not see it.

Fix #41
