### PR TITLE
Allow to reuse  torrent object (or just external use) even after torrentStream instance destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ var encode = require('./encode-metadata');
 var storage = require('./storage');
 var fileStream = require('./file-stream');
 var piece = require('./piece');
-var util = require('util');
 
 var MAX_REQUESTS = 5;
 var CHOKE_TIMEOUT = 5000;
@@ -157,7 +156,7 @@ var torrentStream = function(link, opts) {
 		}
 
 		engine.files = torrent.files.map(function(file) {
-			file = util._extend({}, file);
+			file = Object.create(file);
 			var offsetPiece = (file.offset / torrent.pieceLength) | 0;
 			var endPiece = ((file.offset+file.length-1) / torrent.pieceLength) | 0;
 


### PR DESCRIPTION
Detaches closure from `torrent` object (frome `files` prop in `torrent` obj). 

We cannot use this bellow, because memory leak here, which is caused by closure.

```
var engine =  torrentStream('magnet://..');
var memory_cache = {};

engine.on('ready', function() {

    memory_cache[engine.torrent.infoHash] = engine.torrent;

    /*
    ...
    using of engine
    ...
    */

    engine.destroy();
});
```

Memory will not be released, since `memory_cache[..].files[0].select` will have closure connected to `engine`.

And actually `select` method in `engine.torrent.files[n]` is  side effect. Interaction with `engine.files[n].select` must be enough
