### PR TITLE
pre-convert all IPv4 addresses to Longs to speed up ip blocklist check

### DIFF
--- a/lib/blocklist.js
+++ b/lib/blocklist.js
@@ -3,6 +3,18 @@ var ip = require('ip');
 module.exports = function(blocklist) {
 	if (!blocklist) blocklist = [];
 
+	// Convert all IPv4 addresses to Longs
+	for (var i = 0, l = blocklist.length; i < l; i++) {
+		var block = blocklist[i];
+		if (!block.startAddress || !block.endAddress) continue;
+		blocklist[i].startAddress = typeof block.startAddress === 'number' ? block.startAddress : ip.toLong(block.startAddress);
+		blocklist[i].endAddress = typeof block.endAddress === 'number' ? block.endAddress : ip.toLong(block.endAddress);
+		if (searchAddr >= startAddress && searchAddr <= endAddress) {
+			blockedReason = block.reason || true;
+			break;
+		}
+	}
+
 	return function(addr) {
 		if (!blocklist.length) return false;
 
@@ -12,8 +24,8 @@ module.exports = function(blocklist) {
 		for (var i = 0, l = blocklist.length; i < l; i++) {
 			var block = blocklist[i];
 			if (!block.startAddress || !block.endAddress) continue;
-			var startAddress = ip.toLong(block.startAddress);
-			var endAddress = ip.toLong(block.endAddress);
+			var startAddress = block.startAddress;
+			var endAddress = block.endAddress;
 			if (searchAddr >= startAddress && searchAddr <= endAddress) {
 				blockedReason = block.reason || true;
 				break;


### PR DESCRIPTION
This will fix issue #62.

It will run ip.toLong() on all IP addresses once and store that value. Instead of performing the conversion on each peer IP check \* the number of IPs in the blocklist array, which can become costly with large blocklists.
