### PR TITLE
Updated bittorrent-tracker version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "bitfield": "^0.1.0",
     "bittorrent-dht": "^1.0.0",
-    "bittorrent-tracker": "^1.5.0",
+    "bittorrent-tracker": "^2.0.0",
     "bncode": "^0.5.2",
     "compact2string": "^1.2.0",
     "end-of-stream": "^0.1.4",


### PR DESCRIPTION
Version 1.5 was not working for my project, but 2.0.0 did. All functionality seems to be in order.
