### PR TITLE
use trackers from magnet link when torrent file has none

### DIFF
--- a/index.js
+++ b/index.js
@@ -595,6 +595,10 @@ var torrentStream = function(link, opts, cb) {
 			// Bad cache file - fetch it again
 			if (torrent.infoHash !== infoHash) return discovery.setTorrent(link);
 
+			if (!torrent.announce || !torrent.announce.length) {
+				torrent.announce = link.announce;
+			}
+
 			engine.metadata = bncode.encode(bncode.decode(buf).info);
 			ontorrent(torrent);
 		});


### PR DESCRIPTION
This is a rough guess of the cause of the problem I'm running into based on my limited technical knowledge of how torrents work.

DHT isn't working because of firewall problems. I rely on magnet links that I pass to torrent-stream which contain trackers. Sometimes when exchanging metadata with a peer, the torrent saved doesn't contain any trackers (I'm guessing those peers do not use trackers but only DHT for privacy?). So when torrent-stream relies on the saved torrent file, it'll only rely on DHT which doesn't work because of firewall problems.

This is my crude fix. Maybe you would want to merge tracker arrays before saving the torrent file? Or merge tracker arrays before calling `ontorrent`. You'd know better than I would.