### PR TITLE
leverage the power of parse-torrent

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var magnet = require('magnet-uri');
 var hat = require('hat');
 var pws = require('peer-wire-swarm');
 var bncode = require('bncode');
@@ -55,19 +54,8 @@ var toNumber = function(val) {
 var torrentStream = function(link, opts, cb) {
 	if (typeof opts === 'function') return torrentStream(link, null, opts);
 
-	var metadata = null;
-
-	if (Buffer.isBuffer(link)) {
-		metadata = bncode.encode(bncode.decode(link).info);
-		link = parseTorrent(link);
-	} else if (typeof link === 'string') {
-		link = magnet(link);
-	} else if (!link.infoHash) {
-		link = null;
-	}
-
-	if (!link || !link.infoHash) throw new Error('You must pass a valid torrent or magnet link');
-
+	link = parseTorrent(link);
+	var metadata = link.infoBuffer || null;
 	var infoHash = link.infoHash;
 
 	if (!opts) opts = {};
@@ -599,7 +587,7 @@ var torrentStream = function(link, opts, cb) {
 				opts.trackers = [].concat(opts.trackers || []).concat(link.announce || []);
 			}
 
-			engine.metadata = bncode.encode(bncode.decode(buf).info);
+			engine.metadata = torrent.infoBuffer;
 			ontorrent(torrent);
 		});
 	}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "hat": "0.0.3",
     "ip": "^0.3.0",
     "ip-set": "^1.0.0",
-    "magnet-uri": "^2.0.1",
     "mkdirp": "^0.3.5",
     "parse-torrent": "^4.0.0",
     "peer-wire-swarm": "^0.9.2",


### PR DESCRIPTION
Removes the dependency on `magnet-uri` and simplifies the code by using `parse-torrent`s full power.

The only external change is that the error message from giving an invalid torrent has changed from `You must pass a valid torrent or magnet link` to `Invalid torrent identifier`.