### PR TITLE
Fixes Reconnecting to Wires

### DIFF
--- a/index.js
+++ b/index.js
@@ -581,15 +581,17 @@ var torrentStream = function(link, opts, cb) {
 		if (engine.bitfield) wire.bitfield(engine.bitfield);
 	});
 
-	swarm.pause();
+	var pauseSwarm = true;
 
 	if (link.files && engine.metadata) {
 		swarm.resume();
+		pauseSwarm = false;
 		ontorrent(link);
 	} else {
 		fs.readFile(torrentPath, function(_, buf) {
 			if (destroyed) return;
 			swarm.resume();
+			pauseSwarm = false;
 
 			// We know only infoHash here, not full infoDictionary.
 			// But infoHash is enough to connect to trackers and get peers.
@@ -608,6 +610,9 @@ var torrentStream = function(link, opts, cb) {
 			ontorrent(torrent);
 		});
 	}
+
+	if (pauseSwarm) swarm.pause();
+	delete pauseSwarm;
 
 	engine.critical = function(piece, width) {
 		for (var i = 0; i < (width || 1); i++) critical[piece+i] = true;

--- a/index.js
+++ b/index.js
@@ -608,20 +608,6 @@ var torrentStream = function(link, opts, cb) {
 			ontorrent(torrent);
 		});
 	}
-	
-	engine.discover = function() {
-		discovery.stop();
-		discovery = peerDiscovery(opts);
-		discovery.on('peer', function(addr) {
-			if (blocked.contains(addr.split(':')[0])) {
-				engine.emit('blocked-peer', addr);
-			} else {
-				engine.emit('peer', addr);
-				engine.connect(addr);
-			}
-		});
-		discovery.setTorrent(link);
-	};
 
 	engine.critical = function(piece, width) {
 		for (var i = 0; i < (width || 1); i++) critical[piece+i] = true;
@@ -640,7 +626,7 @@ var torrentStream = function(link, opts, cb) {
 			return b.priority - a.priority;
 		});
 		
-		if (swarm.paused) this.discover();
+		if (swarm.paused) discovery.restart();
 
 		refresh();
 	};

--- a/lib/peer-discovery.js
+++ b/lib/peer-discovery.js
@@ -82,6 +82,15 @@ module.exports = function(torrent, opts) {
 		if (discovery.tracker) discovery.tracker.stop();
 		if (discovery.dht) discovery.dht.destroy();
 	};
+	
+	discovery.restart = function() {
+		if (discovery.tracker) discovery.tracker.stop();
+		if (discovery.dht) {
+			discovery.dht.destroy();
+			discovery.dht = createDHT(torrent.infoHash);
+		}
+		if (torrent) discovery.tracker = createTracker(torrent);
+	};
 
 	if (torrent) discovery.setTorrent(torrent);
 


### PR DESCRIPTION
As mentioned on https://github.com/mafintosh/peerflix/issues/203

Reinitializes peer search on ``engine.files[i].select()`` if the swarm was previously paused and adds ``engine.discover()`` that also restarts peer search.