### PR TITLE
rimraf - Increase maxBusyTries to 60

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -146,7 +146,7 @@ module.exports = function(folder) {
 			that.close(function(err) {
 				if (err) return cb(err);
 				var root = torrent.files[0].path.split(path.sep)[0];
-				rimraf(path.join(folder, root), cb);
+				rimraf(path.join(folder, root), { maxBusyTries: 60 }, cb);
 			});
 		};
 


### PR DESCRIPTION
Sometimes rimraf does not remove the video files, increasing maxBusyTries to 60 solved this for me.

Each attempt to remove a file is done every 1 second, changing this from the default 2 tries to 60 equals in a maximum total of 1 minute.

To be noted: rimraf is async

Detailed description of the issue: https://github.com/mafintosh/peerflix/issues/190#issuecomment-107161486