### PR TITLE
Pulse to prevent network flooding

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,8 +101,8 @@ var torrentStream = function(link, opts, cb) {
 	engine.amInterested = false;
 	engine.store = null;
 	engine.swarm = swarm;
-	engine.FLOOD = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
-	engine.PULSE = Number.MAX_SAFE_INTEGER;  // Do not pulse
+	engine.flood = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
+	engine.pulse = Number.MAX_SAFE_INTEGER;  // Do not pulse
 
 	var discovery = peerDiscovery(opts);
 	var blocked = blocklist(opts.blocklist);
@@ -367,7 +367,7 @@ var torrentStream = function(link, opts, cb) {
 			if (wire.requests.length >= MAX_REQUESTS) return true;
 			
 			// Pulse, or flood (default)
-			if (swarm.downloaded > engine.FLOOD && swarm.downloadSpeed() > engine.PULSE) 
+			if (swarm.downloaded > engine.flood && swarm.downloadSpeed() > engine.pulse) 
        			return true;
        			
 			var rank = speedRanker(wire);

--- a/index.js
+++ b/index.js
@@ -101,8 +101,8 @@ var torrentStream = function(link, opts, cb) {
 	engine.amInterested = false;
 	engine.store = null;
 	engine.swarm = swarm;
-	engine.DOWNLOAD = Number.MAX_SAFE_INTEGER;  // Growler defaults:
-	engine.THROTTLE = Number.MAX_SAFE_INTEGER;  // Do not growl
+	engine.DOWNLOAD = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
+	engine.THROTTLE = Number.MAX_SAFE_INTEGER;  // Do not pulse
 
 	var discovery = peerDiscovery(opts);
 	var blocked = blocklist(opts.blocklist);
@@ -366,7 +366,7 @@ var torrentStream = function(link, opts, cb) {
 		var select = function(wire, hotswap) {
 			if (wire.requests.length >= MAX_REQUESTS) return true;
 			
-			// Growl. Default is no growling.
+			// Pulse. Default is no pulsing (flood).
 			if (swarm.downloaded > engine.DOWNLOAD && swarm.downloadSpeed() > engine.THROTTLE) 
        			return true;
        			

--- a/index.js
+++ b/index.js
@@ -101,8 +101,8 @@ var torrentStream = function(link, opts, cb) {
 	engine.amInterested = false;
 	engine.store = null;
 	engine.swarm = swarm;
-	engine.DOWNLOAD = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
-	engine.THROTTLE = Number.MAX_SAFE_INTEGER;  // Do not pulse
+	engine.FLOOD = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
+	engine.PULSE = Number.MAX_SAFE_INTEGER;  // Do not pulse
 
 	var discovery = peerDiscovery(opts);
 	var blocked = blocklist(opts.blocklist);
@@ -367,7 +367,7 @@ var torrentStream = function(link, opts, cb) {
 			if (wire.requests.length >= MAX_REQUESTS) return true;
 			
 			// Pulse. Default is no pulsing (flood).
-			if (swarm.downloaded > engine.DOWNLOAD && swarm.downloadSpeed() > engine.THROTTLE) 
+			if (swarm.downloaded > engine.FLOOD && swarm.downloadSpeed() > engine.PULSE) 
        			return true;
        			
 			var rank = speedRanker(wire);

--- a/index.js
+++ b/index.js
@@ -638,6 +638,31 @@ var torrentStream = function(link, opts, cb) {
 		refresh();
 	};
 
+	engine.setPulse = function(bps) {
+		// Set minimum byte/second pulse starting now (dynamic)
+		// Eg. Start pulsing at minimum 312 KBps:
+		// engine.setPulse(312*1024);
+		
+		engine.pulse = bps;
+	};
+	
+	engine.setFlood = function(b) {
+		// Set bytes to flood starting now (dynamic)
+		// Eg. Start flooding for next 10 MB:
+		// engine.setFlood(10*1024*1024)
+		
+		engine.flood = b + swarm.downloaded;
+	};
+	
+	engine.setFloodedPulse = function(b, bps) {
+		// Set bytes to flood before starting a minimum byte/second pulse (dynamic)
+		// Eg. Start flooding for next 10 MB, then start pulsing at minimum 312 KBps:
+		// engine.setFloodedPulse(10*1024*1024, 312*1024);
+		
+		engine.setFlood(b);
+		engine.setPulse(bps);
+	};
+	
 	engine.connect = function(addr) {
 		swarm.add(addr);
 	};

--- a/index.js
+++ b/index.js
@@ -668,8 +668,8 @@ var torrentStream = function(link, opts, cb) {
 		// Eg. Flood the network starting now:
 		// engine.flood();
 		
-		engine.setFlood(Number.MAX_SAFE_INTEGER);
-		engine.setPulse(Number.MAX_SAFE_INTEGER);
+		engine.flood = Number.MAX_SAFE_INTEGER;
+		engine.pulse = Number.MAX_SAFE_INTEGER;
 	};
 	
 	engine.connect = function(addr) {

--- a/index.js
+++ b/index.js
@@ -62,7 +62,9 @@ var torrentStream = function(link, opts, cb) {
 	if (!opts.id) opts.id = '-TS0008-'+hat(48);
 	if (!opts.tmp) opts.tmp = TMP;
 	if (!opts.name) opts.name = 'torrent-stream';
-
+	if (!opts.flood) opts.flood = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
+	if (!opts.pulse) opts.pulse = Number.MAX_SAFE_INTEGER;  // Do not pulse
+	
 	var usingTmp = false;
 	var destroyed = false;
 
@@ -101,8 +103,8 @@ var torrentStream = function(link, opts, cb) {
 	engine.amInterested = false;
 	engine.store = null;
 	engine.swarm = swarm;
-	engine.flood = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
-	engine.pulse = Number.MAX_SAFE_INTEGER;  // Do not pulse
+	engine.flood = opts.flood;
+        engine.pulse = opts.pulse;
 
 	var discovery = peerDiscovery(opts);
 	var blocked = blocklist(opts.blocklist);

--- a/index.js
+++ b/index.js
@@ -366,7 +366,7 @@ var torrentStream = function(link, opts, cb) {
 		var select = function(wire, hotswap) {
 			if (wire.requests.length >= MAX_REQUESTS) return true;
 			
-			// Pulse. Default is no pulsing (flood).
+			// Pulse, or flood (default)
 			if (swarm.downloaded > engine.FLOOD && swarm.downloadSpeed() > engine.PULSE) 
        			return true;
        			

--- a/index.js
+++ b/index.js
@@ -663,6 +663,15 @@ var torrentStream = function(link, opts, cb) {
 		engine.setPulse(bps);
 	};
 	
+	engine.flood = function() {
+		// Reset flood/pulse values to default (dynamic)
+		// Eg. Flood the network starting now:
+		// engine.flood();
+		
+		engine.setFlood(Number.MAX_SAFE_INTEGER);
+		engine.setPulse(Number.MAX_SAFE_INTEGER);
+	};
+	
 	engine.connect = function(addr) {
 		swarm.add(addr);
 	};

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ var torrentStream = function(link, opts, cb) {
 	if (!opts.id) opts.id = '-TS0008-'+hat(48);
 	if (!opts.tmp) opts.tmp = TMP;
 	if (!opts.name) opts.name = 'torrent-stream';
-	if (!opts.flood) opts.flood = Number.MAX_SAFE_INTEGER;  // Pulse defaults:
+	if (!opts.flood) opts.flood = 0;                        // Pulse defaults:
 	if (!opts.pulse) opts.pulse = Number.MAX_SAFE_INTEGER;  // Do not pulse
 	
 	var usingTmp = false;
@@ -668,7 +668,7 @@ var torrentStream = function(link, opts, cb) {
 		// Eg. Flood the network starting now:
 		// engine.flood();
 		
-		engine.flood = Number.MAX_SAFE_INTEGER;
+		engine.flood = 0;
 		engine.pulse = Number.MAX_SAFE_INTEGER;
 	};
 	

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ var torrentStream = function(link, opts, cb) {
 	engine.store = null;
 	engine.swarm = swarm;
 	engine.flood = opts.flood;
-        engine.pulse = opts.pulse;
+	engine.pulse = opts.pulse;
 
 	var discovery = peerDiscovery(opts);
 	var blocked = blocklist(opts.blocklist);

--- a/index.js
+++ b/index.js
@@ -101,6 +101,8 @@ var torrentStream = function(link, opts, cb) {
 	engine.amInterested = false;
 	engine.store = null;
 	engine.swarm = swarm;
+	engine.DOWNLOAD = Number.MAX_SAFE_INTEGER;  // Growler defaults:
+	engine.THROTTLE = Number.MAX_SAFE_INTEGER;  // Do not growl
 
 	var discovery = peerDiscovery(opts);
 	var blocked = blocklist(opts.blocklist);
@@ -363,7 +365,11 @@ var torrentStream = function(link, opts, cb) {
 
 		var select = function(wire, hotswap) {
 			if (wire.requests.length >= MAX_REQUESTS) return true;
-
+			
+			// Growl. Default is no growling.
+			if (swarm.downloaded > engine.DOWNLOAD && swarm.downloadSpeed() > engine.THROTTLE) 
+       			return true;
+       			
 			var rank = speedRanker(wire);
 
 			for (var i = 0; i < engine.selection.length; i++) {


### PR DESCRIPTION
Seem to have an early swarm-level solution for network flooding. Just a one-liner in the selector.

    if (swarm.downloaded > engine.flood && swarm.downloadSpeed() > engine.pulse) 
        return true;
Requests to peers are prevented above a threshold swarm download rate, and resumed  below the threshold, producing a *pulse* in the network, rather than a flood (see fig 1).

A limited flood of the buffer can be set before pulsing begins. 

![image](https://cloud.githubusercontent.com/assets/1641613/8506206/6bee6326-21d7-11e5-856e-a2e20b64502d.png)

Default is no pulsing (existing behavior). The flood limit and pulse threshold can be set dynamically by a torrent-stream *consumer*.

For example in a request for a 720p video segment:

    engine.flood = 10  * 1024 * 1024 + engine.swarm.downloaded; //  10 MB flood
    engine.pulse = 312 * 1024;                                  // 312 KBps pulse (720p)

or

    engine.setFlood(10*1024*1024);
    engine.setPulse(312*1024);

or

    engine.setFloodedPulse(10*1024*1024, 312*1024);

Reset defaults:

    engine.flood();