### PR TITLE
Resolve an uncommon conflict on missing piecesMap

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -86,6 +86,8 @@ module.exports = function(folder) {
 				if (!targets.length) return cb(new Error('no file matching the requested range?'));
 			}
 
+			if (!targets) return cb(new Error('no targets for the given index?'));
+
 			var buffers = [];
 			var i = 0;
 			var end = targets.length;


### PR DESCRIPTION
```
Resolve an uncommon conflict on missing piecesMap
- prevents 'error length of undefined'
```


Hello, this verification allows to start streaming some torrents that don't want to start without it. It's an uncommon error I only encountered with one file so far: 

- hash magnet: 484b232de223f7189ee3b53aa3113333ee844098
- console error without this modification: 

``` 
[ERROR] TypeError: Cannot read property 'length' of undefined TypeError: Cannot read property 'length' of undefined
    at Object.that.read (c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\lib\storage.js:91:21)
    at Object.that.read (c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\lib\storage-buffer.js:14:13)
    at Object.that.read (c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\lib\storage-buffer.js:8:50)
    at loop (c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\index.js:547:17)
    at c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\index.js:548:71
    at c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\lib\storage.js:113:46
    at apply (c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\node_modules\thunky\index.js:16:28)
    at c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\node_modules\thunky\index.js:20:25
    at c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\lib\storage.js:44:6
    at FSReqWrap.cb [as oncomplete] (fs.js:205:19)
c:\GIT\desktop\node_modules\peerflix\node_modules\torrent-stream\lib\storage.js:91 Uncaught TypeError: Cannot read property 'length' of undefined
```

My environment: 
- Windows 8.1 x64
- NWjs (node-webkit) 12.1
- custom Peerflix module (based on 0.29.2 with torrent-stream 0.21.0)