### PR TITLE
fix possible crash when exchanging metadata

### DIFF
--- a/lib/exchange-metadata.js
+++ b/lib/exchange-metadata.js
@@ -19,7 +19,11 @@ module.exports = function(engine, callback) {
 	return function(wire) {
 		var metadata = engine.metadata;
 		wire.once('extended', function(id, handshake) {
-			handshake = bncode.decode(handshake);
+			try {
+				handshake = bncode.decode(handshake);
+			} catch (err) {
+				return;
+			}
 
 			if (id || !handshake.m || handshake.m.ut_metadata === undefined) return;
 


### PR DESCRIPTION
```
index-0 (err): Error: uneven number of keys and values A
index-0 (err): at cb_end (/home/app/torrent-server/node_modules/torrent-stream/node_modules/bncode/bncode.js:292:19)
index-0 (err): at BdecodeSMachine.parse (/home/app/torrent-server/node_modules/torrent-stream/node_modules/bncode/bncode.js:166:17)
index-0 (err): at Bdecode.decode (/home/app/torrent-server/node_modules/torrent-stream/node_modules/bncode/bncode.js:322:14)
index-0 (err): at Object.decode (/home/app/torrent-server/node_modules/torrent-stream/node_modules/bncode/bncode.js:444:11)
index-0 (err): at null. (/home/app/torrent-server/node_modules/torrent-stream/lib/exchange-metadata.js:22:23)
index-0 (err): at g (events.js:199:16)
index-0 (err): at emit (events.js:110:17)
index-0 (err): at Wire._onextended (/home/app/torrent-server/node_modules/torrent-stream/node_modules/peer-wire-swarm/node_modules/peer-wire-protocol/index.js:306:7)
index-0 (err): at onmessage (/home/app/torrent-server/node_modules/torrent-stream/node_modules/peer-wire-swarm/node_modules/peer-wire-protocol/index.js:112:16)
index-0 (err): at Wire._write (/home/app/torrent-server/node_modules/torrent-stream/node_modules/peer-wire-swarm/node_modules/peer-wire-protocol/index.js:355:8)
```

Sometimes I get this crash from peers.