### PR TITLE
engine.remove calls destroy too and the callback is now optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -711,11 +711,12 @@ var torrentStream = function (link, opts, cb) {
   }
 
   var removeTorrent = function (cb) {
+    engine.destroy()
     fs.unlink(torrentPath, function (err) {
-      if (err) return cb(err)
+      if (err && typeof cb === 'function') return cb(err)
       fs.rmdir(path.dirname(torrentPath), function (err) {
-        if (err && err.code !== 'ENOTEMPTY') return cb(err)
-        cb()
+        if (err && err.code !== 'ENOTEMPTY' && typeof cb === 'function') return cb(err)
+        if(typeof cb === 'function') cb()
       })
     })
   }


### PR DESCRIPTION
Fixed #143 
Now the callback is optional and engine.remove() calls automatically engine.destroy.
@mafintosh Sorry for the late fix but the college is destroying me (just to stay on topic), I'm used to use useless semicolon when I call function, but I respected your style here :)