### PR TITLE
Send `complete` event to tracker once all files have been downloaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,8 +217,39 @@ var torrentStream = function (link, opts, cb) {
       if (!engine.selection.length) {
         engine.emit('idle')
 
+        // check if all pieces have been downloaded
+        var complete = true
+        var bits = engine.torrent.pieces.length
+        var bytes = bits / 8 | 0
+        var rem = bits % 8
+        var buffer = engine.bitfield.buffer
+
+        for (var i = 0; i < bytes; i++) {
+          if (buffer[i] !== 255) {
+            complete = false // every byte must be full of ones
+            break
+          }
+        }
+
+        if (complete && rem > 0) {
+          var mask = 256 - Math.pow(2, 8 - rem); // the last byte may be not full
+          if (buffer[bytes] !== mask) {
+            complete = false
+          }
+        }
+
+        if (complete) {
+          engine.emit('complete')
+        }
+
         if (discovery.tracker && discovery.tracker !== true) {
-          discovery.tracker.complete()
+          if (complete) {
+            // all pieces have been downloaded, send the complete event to the tracker
+            discovery.tracker.complete()
+          } else {
+            // send our stats to the tracker now
+            discovery.tracker.update()
+          }
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -214,7 +214,13 @@ var torrentStream = function (link, opts, cb) {
         oninterestchange()
       }
 
-      if (!engine.selection.length) engine.emit('idle')
+      if (!engine.selection.length) {
+        engine.emit('idle')
+
+        if (discovery.tracker && discovery.tracker !== true) {
+          discovery.tracker.complete()
+        }
+      }
     }
 
     var onpiececomplete = function (index, buffer) {


### PR DESCRIPTION
This fixes #109, fixes #48, closes #113
