### PR TITLE
README: add engine.swarm.downloadSpeed() and clarify engine.swarm.downloaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ The attached [peer-wire-swarm](https://github.com/mafintosh/peer-wire-swarm) ins
 #### `engine.swarm.downloaded`
 
 Shows the total bytes downloaded. With this you can know how much you downloaded and how many bytes you still have to download to reach the end of the file. 
+#### `engine.swarm.downloadSpeed()`
+
+Shows the download speed in bytes/s
 
 #### `file = engine.files[...]`
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ The attached [peer-wire-swarm](https://github.com/mafintosh/peer-wire-swarm) ins
 
 #### `engine.swarm.downloaded`
 
-Shows the total bytes downloaded. With this you can know how much you downloaded and how many bytes you still have to download to reach the end of the file. 
+Shows the total bytes downloaded. With this you can know how much you downloaded.
+
 #### `engine.swarm.downloadSpeed()`
 
 Shows the download speed in bytes/s


### PR DESCRIPTION
There's 2 parts to this pull request. The first one should be straight forward - "Add engine.swarm.downloadSpeed()" to the documentation

The second is a clarification. From my tests, `torrent-stream` always ends up downloading more than the `totalLength` and hence `engine.swarm.downloaded` isnt a good metric to figure out what's left. In other words, trying to do a "%" by `engine.swarm.downloaded/totalLength` always goes above 100%. 