### PR TITLE
Buffer check based on length instead of !undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -613,7 +613,7 @@ var torrentStream = function (link, opts, cb) {
 
       // We know only infoHash here, not full infoDictionary.
       // But infoHash is enough to connect to trackers and get peers.
-      if (!buf) return discovery.setTorrent(link)
+      if (buf.length == 0) return discovery.setTorrent(link)
 
       var torrent = parseTorrent(buf)
 


### PR DESCRIPTION
Production tests showed this small bug, and this is the solution.