### PR TITLE
ontorrent in nextTick

### DIFF
--- a/index.js
+++ b/index.js
@@ -608,7 +608,9 @@ var torrentStream = function (link, opts, cb) {
 
   if (link.files && engine.metadata) {
     swarm.resume()
-    ontorrent(link)
+    process.nextTick(function () {
+      ontorrent(link)
+    })
   } else {
     fs.readFile(torrentPath, function (_, buf) {
       if (destroyed) return


### PR DESCRIPTION
If passing torrent file as a buffer, need to defer `ontorrent` to the next tick, so the user can listen on the `verifying` event.