### PR TITLE
Add sanitize lib for filename to avoid reserved character

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var FSChunkStore = require('fs-chunk-store')
 var ImmediateChunkStore = require('immediate-chunk-store')
 var peerDiscovery = require('torrent-discovery')
 var bufferFrom = require('buffer-from')
+var sanitize = require('sanitize-filename')
 
 var blocklist = require('ip-set')
 var exchangeMetadata = require('./lib/exchange-metadata')
@@ -131,7 +132,7 @@ var torrentStream = function (link, opts, cb) {
     engine.store = ImmediateChunkStore(storage(torrent.pieceLength, {
       files: torrent.files.map(function (file) {
         return {
-          path: path.join(opts.path, file.path),
+          path: path.join(opts.path, sanitize(file.path)),
           length: file.length,
           offset: file.offset
         }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "peer-wire-swarm": "^0.12.0",
     "rimraf": "^2.2.5",
     "torrent-discovery": "^5.2.0",
-    "torrent-piece": "^1.0.0"
+    "torrent-piece": "^1.0.0",
+    "sanitize-filename": "^1.6.1"
   },
   "devDependencies": {
     "buffer-alloc": "^1.1.0",


### PR DESCRIPTION
Add sanitize lib for filename to avoid reserved character on specific filesystem

The lib used is [node-sanitize-filename](https://github.com/parshap/node-sanitize-filename) :
>Sanitize a string to be safe for use as a filename by removing directory paths and invalid characters.

This fix issue #168 
This is a alternative solution of PR #178 