### PR TITLE
fix race condition involving engine.destroy() and `ready` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -554,7 +554,9 @@ var torrentStream = function (link, opts, cb) {
         onupdate()
       }
 
-      rechokeIntervalId = setInterval(onrechoke, RECHOKE_INTERVAL)
+      if (!destroyed) {
+        rechokeIntervalId = setInterval(onrechoke, RECHOKE_INTERVAL)
+      }
 
       process.nextTick(function () {
         engine.emit('torrent', torrent)


### PR DESCRIPTION
The 'ready' event sets up an interval timer that is cleared in
`destroy()`. However, in some situations, it is possible to for the
interval to be created after `destroy()` has run, resulting in an
interval timer that is never cleared, and thus an app that does not
exit when it is supposed to. This change fixes the issue and adds a
test for it.

Refs: https://github.com/mafintosh/torrent-stream/issues/198