### PR TITLE
Added utp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Create a new engine instance. Options can contain the following
 	                      // Defaults to true
 	dht: true,            // Whether or not to use DHT to initialize the swarm.
 	                      // Defaults to true
+	utp: false,           // Whether or not to use UTP connections.
+	                      // Defaults to false
 	tracker: true,        // Whether or not to use trackers from torrent file or magnet link
 	                      // Defaults to true
 	trackers: [

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ var torrentStream = function (link, opts, cb) {
   }
 
   var engine = new events.EventEmitter()
-  var swarm = pws(infoHash, opts.id, { size: (opts.connections || opts.size), speed: 10 })
+  var swarm = pws(infoHash, opts.id, { size: (opts.connections || opts.size), speed: 10, utp: opts.utp})
   var torrentPath = path.join(opts.tmp, opts.name, infoHash + '.torrent')
 
   if (cb) engine.on('ready', cb.bind(null, engine))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torrent-stream",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Low level streaming torrent client that exposes files as node.js streams and downloads pieces based on demand",
   "repository": "git://github.com/mafintosh/torrent-stream.git",
   "scripts": {


### PR DESCRIPTION
Passing utp option to `peer-wire-swarm` to enable utp. Seems like a lot of torrent clients only support utp, so enabling utp allows to connect to more peers. Is there a reason why this was disabled by default?