### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var BAD_PIECE_STRIKES_DURATION = 120000 // 2 minutes
 var RECHOKE_INTERVAL = 10000
 var RECHOKE_OPTIMISTIC_DURATION = 2
 
-var TMP = fs.existsSync('/tmp') ? '/tmp' : os.tmpDir()
+var TMP = fs.existsSync('/tmp') ? '/tmp' : os.tmpdir()
 
 var noop = function () {}
 


### PR DESCRIPTION
Windows issue on os.tmpDir, deprecated

D:\node-lab\node-torrent\node_modules\torrent-stream\index.js:36
var TMP = fs.existsSync('/tmp') ? '/tmp' : os.tmpDir()
                                              ^

TypeError: os.tmpDir is not a function
    at Object.<anonymous> (D:\node-lab\node-torrent\node_modules\torrent-stream\index.js:36:47)
    at Module._compile (internal/modules/cjs/loader.js:1076:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:941:32)
    at Function.Module._load (internal/modules/cjs/loader.js:782:14)
    at Module.require (internal/modules/cjs/loader.js:965:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (D:\node-lab\node-torrent\index.js:1:21)
    at Module._compile (internal/modules/cjs/loader.js:1076:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)