### PR TITLE
use `os.tmpdir()` in case `os.tmpDir()` is unavailable

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var BAD_PIECE_STRIKES_DURATION = 120000 // 2 minutes
 var RECHOKE_INTERVAL = 10000
 var RECHOKE_OPTIMISTIC_DURATION = 2
 
-var TMP = fs.existsSync('/tmp') ? '/tmp' : os.tmpDir()
+var TMP = fs.existsSync('/tmp') ? '/tmp' : (os.tmpdir ? os.tmpdir() : os.tmpDir())
 
 var noop = function () {}
 


### PR DESCRIPTION
in node14 the `os.tmpDir()` is completelly removed, and replaced with `os.tmpdir()` function.
in this PR, I added a ternary to use `os.tmdir()` if it is available, otherwise the old `os.tmpDir()` will be used.
this workaround will make the code work on both node14 or any other versions before that.